### PR TITLE
Embed images

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -5,7 +5,7 @@ const UglifyJS = require("uglify-js");
 const FILE_PREFIX = "file://";
 const BASE_64_PREFIX = `base64,`;
 const QUOTES = `("|')`;
-const QUOTES_REGEX = new RegExp(`("|'|`)`);
+const QUOTES_REGEX = new RegExp(`("|'|\`)`);
 const BASE_64_FILE_REGEX = new RegExp(`;${BASE_64_PREFIX}file:\/\/(.+)${QUOTES}`);
 const BASE_64_ICON_REGEX = new RegExp(`;${BASE_64_PREFIX}file:\/\/(.+)`);
 const SPIRA_APP_EXTENSION = "spiraapp";
@@ -138,7 +138,7 @@ function validateManifest(manifest) {
         { name: "settingGroup",  required: false, type: typeEnums.string, max: 50 }
     ];   
     const productSettingProps = [
-        { name: "settingTypeId",  required: true,  type: typeEnums.int,    min: SETTING_TYPE_ID_MIN, max: SETTING_TYPE_ID_MIN },    
+        { name: "settingTypeId",  required: true,  type: typeEnums.int,    min: SETTING_TYPE_ID_MIN, max: SETTING_TYPE_ID_MAX },    
         { name: "name",           required: true,  type: typeEnums.string, max: 255 },    
         { name: "caption",        required: true,  type: typeEnums.string, max: 50 },     
         { name: "placeholder",    required: false, type: typeEnums.string, max: 255 },  


### PR DESCRIPTION
When writing the docs for the apps, I noticed that we still had base64 encoded images allowed inside the manifest and js / css files. This is fine for our internal spiraapps, but not for 3rd parties. While we can assess the base64 encoded strings for safety, it will likely make things easier for us if we can see the actual images themselves, and rely on the packager to put everything together properly. It will also probably be a better developer experience.

This branch improves the packager to find and replace file:// in more places than before in a safe way. 

I have tested this locally on a spiraapp with an svg link instead of base64 encoded string. Because the code looks for a match, if it does not find one it will lead to no change.

It does not check the potential files to see if they have any Base64 encoded looking strings. We could do that but I thought that may be easier to manually check for now, as I am not sure how reliable the regex match for that would be. We could explore